### PR TITLE
fix: log request payload

### DIFF
--- a/op-node/rollup/derive/calldata_source.go
+++ b/op-node/rollup/derive/calldata_source.go
@@ -155,15 +155,15 @@ func DataFromEVMTransactions(config *rollup.Config, daCfg *da.DAConfig, batcherA
 				blobRes, err := daCfg.Client.RetrieveBlob(context.Background(), blobRequest)
 				if err != nil {
 					retrieveReqJSON, _ := json.Marshal(struct {
-						batch_header_hash      string
-						blob_index             uint32
-						reference_block_number uint32
-						quorum_id              uint32
+						BatchHeaderHash      string
+						BlobIndex            uint32
+						ReferenceBlockNumber uint32
+						QuorumId             uint32
 					}{
-						batch_header_hash:      base64.StdEncoding.EncodeToString(frameRef.BatchHeaderHash),
-						blob_index:             frameRef.BlobIndex,
-						reference_block_number: frameRef.ReferenceBlockNumber,
-						quorum_id:              frameRef.QuorumIds[0],
+						BatchHeaderHash:      base64.StdEncoding.EncodeToString(frameRef.BatchHeaderHash),
+						BlobIndex:            frameRef.BlobIndex,
+						ReferenceBlockNumber: frameRef.ReferenceBlockNumber,
+						QuorumId:             frameRef.QuorumIds[0],
 					})
 					log.Warn("could not retrieve data from EigenDA", "request", string(retrieveReqJSON), "err", err)
 					return nil


### PR DESCRIPTION
# Context
the log will always be {}, because the json marshal won't marshall private field

an example of this:
```golang
package main

import (
	"encoding/json"
	"fmt"
)

func main() {
	j1, _ := json.Marshal(struct {
		A string
	}{
		A: "1",
	})
	fmt.Println(string(j1))
	j2, _ := json.Marshal(struct {
		a string
	}{
		a: "1",
	})
	fmt.Println(string(j2))
}
```
output:
```
{"A":"1"}
{}
```
