### PR TITLE
feat(eigenda): support prefix derivation

### DIFF
--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -83,13 +83,14 @@ type CLIConfig struct {
 	// ActiveSequencerCheckDuration is the duration between checks to determine the active sequencer endpoint.
 	ActiveSequencerCheckDuration time.Duration
 
-	TxMgrConfig   txmgr.CLIConfig
-	LogConfig     oplog.CLIConfig
-	MetricsConfig opmetrics.CLIConfig
-	PprofConfig   oppprof.CLIConfig
-	RPC           oprpc.CLIConfig
-	PlasmaDA      plasma.CLIConfig
-	DAConfig      eigenda.CLIConfig
+	TxMgrConfig             txmgr.CLIConfig
+	LogConfig               oplog.CLIConfig
+	MetricsConfig           opmetrics.CLIConfig
+	PprofConfig             oppprof.CLIConfig
+	RPC                     oprpc.CLIConfig
+	PlasmaDA                plasma.CLIConfig
+	DAConfig                eigenda.CLIConfig
+	PrefixDerivationEnabled bool
 }
 
 func (c *CLIConfig) Check() error {
@@ -169,5 +170,6 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		RPC:                          oprpc.ReadCLIConfig(ctx),
 		PlasmaDA:                     plasma.ReadCLIConfig(ctx),
 		DAConfig:                     eigenda.ReadCLIConfig(ctx),
+		PrefixDerivationEnabled:      ctx.Bool(flags.PrefixDerivationEnabledFlag.Name),
 	}
 }

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -75,7 +75,8 @@ type BatcherService struct {
 
 	NotSubmittingOnStart bool
 
-	DA eigenda.IEigenDA
+	DA                      eigenda.IEigenDA
+	PrefixDerivationEnabled bool
 }
 
 // BatcherServiceFromCLIConfig creates a new BatcherService from a CLIConfig.
@@ -125,6 +126,7 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 	if err := bs.initDA(cfg); err != nil {
 		return fmt.Errorf("failed to init DA: %w", err)
 	}
+	bs.PrefixDerivationEnabled = cfg.PrefixDerivationEnabled
 	bs.initDriver()
 	if err := bs.initRPCServer(cfg); err != nil {
 		return fmt.Errorf("failed to start RPC server: %w", err)
@@ -293,16 +295,17 @@ func (bs *BatcherService) initMetricsServer(cfg *CLIConfig) error {
 
 func (bs *BatcherService) initDriver() {
 	bs.driver = NewBatchSubmitter(DriverSetup{
-		Log:              bs.Log,
-		Metr:             bs.Metrics,
-		RollupConfig:     bs.RollupConfig,
-		Config:           bs.BatcherConfig,
-		Txmgr:            bs.TxManager,
-		L1Client:         bs.L1Client,
-		EndpointProvider: bs.EndpointProvider,
-		ChannelConfig:    bs.ChannelConfig,
-		PlasmaDA:         bs.PlasmaDA,
-		DA:               bs.DA,
+		Log:                     bs.Log,
+		Metr:                    bs.Metrics,
+		RollupConfig:            bs.RollupConfig,
+		Config:                  bs.BatcherConfig,
+		Txmgr:                   bs.TxManager,
+		L1Client:                bs.L1Client,
+		EndpointProvider:        bs.EndpointProvider,
+		ChannelConfig:           bs.ChannelConfig,
+		PlasmaDA:                bs.PlasmaDA,
+		DA:                      bs.DA,
+		PrefixDerivationEnabled: bs.PrefixDerivationEnabled,
 	})
 }
 

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -128,6 +128,12 @@ var (
 		Value:   2 * time.Minute,
 		EnvVars: prefixEnvVars("ACTIVE_SEQUENCER_CHECK_DURATION"),
 	}
+	PrefixDerivationEnabledFlag = &cli.BoolFlag{
+		Name:    "da-prefix-derivation-enabled",
+		Usage:   "Enable prefix derivation",
+		Value:   false,
+		EnvVars: prefixEnvVars("DA_PREFIX_DERIVATION_ENABLED"),
+	}
 	// Legacy Flags
 	SequencerHDPathFlag = txmgr.SequencerHDPathFlag
 )
@@ -152,6 +158,7 @@ var optionalFlags = []cli.Flag{
 	BatchTypeFlag,
 	DataAvailabilityTypeFlag,
 	ActiveSequencerCheckDurationFlag,
+	PrefixDerivationEnabledFlag,
 }
 
 func init() {

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -359,6 +359,12 @@ var (
 		Value:   "http://da:26658",
 		EnvVars: prefixEnvVars("DA_RPC"),
 	}
+	PrefixDerivationEnabledFlag = &cli.BoolFlag{
+		Name:    "da-prefix-derivation-enabled",
+		Usage:   "Enable prefix derivation",
+		Value:   false,
+		EnvVars: prefixEnvVars("DA_PREFIX_DERIVATION_ENABLED"),
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -406,6 +412,7 @@ var optionalFlags = []cli.Flag{
 	ConductorRpcFlag,
 	ConductorRpcTimeoutFlag,
 	SafeDBPath,
+	PrefixDerivationEnabledFlag,
 }
 
 var DeprecatedFlags = []cli.Flag{

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -54,7 +54,8 @@ type Config struct {
 	// but if log-events are not coming in (e.g. not syncing blocks) then the reload ensures the config stays accurate.
 	RuntimeConfigReloadInterval time.Duration
 
-	DA eigenda.Config
+	DA                      eigenda.Config
+	PrefixDerivationEnabled bool
 
 	// Optional
 	Tracer    Tracer

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -403,7 +403,7 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config, snapshotLog log.Logger
 	} else {
 		n.safeDB = safedb.Disabled
 	}
-	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, n.beacon, n, n, n.log, snapshotLog, n.metrics, cfg.ConfigPersistence, n.safeDB, &cfg.Sync, sequencerConductor, plasmaDA, &cfg.DA)
+	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, n.beacon, n, n, n.log, snapshotLog, n.metrics, cfg.ConfigPersistence, n.safeDB, &cfg.Sync, sequencerConductor, plasmaDA, &cfg.DA, cfg.PrefixDerivationEnabled)
 	return nil
 }
 

--- a/op-node/rollup/derive/blob_data_source_test.go
+++ b/op-node/rollup/derive/blob_data_source_test.go
@@ -42,7 +42,7 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	}
 	calldataTx, _ := types.SignNewTx(privateKey, signer, txData)
 	txs := types.Transactions{calldataTx}
-	data, blobHashes := dataAndHashesFromTxs(txs, &config, batcherAddr, nil)
+	data, blobHashes := dataAndHashesFromTxs(txs, &config, batcherAddr, nil, false)
 	require.Equal(t, 1, len(data))
 	require.Equal(t, 0, len(blobHashes))
 
@@ -57,14 +57,14 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	}
 	blobTx, _ := types.SignNewTx(privateKey, signer, blobTxData)
 	txs = types.Transactions{blobTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, nil)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, nil, false)
 	require.Equal(t, 1, len(data))
 	require.Equal(t, 1, len(blobHashes))
 	require.Nil(t, data[0].calldata)
 
 	// try again with both the blob & calldata transactions and make sure both are picked up
 	txs = types.Transactions{blobTx, calldataTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, nil)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, nil, false)
 	require.Equal(t, 2, len(data))
 	require.Equal(t, 1, len(blobHashes))
 	require.NotNil(t, data[1].calldata)
@@ -72,7 +72,7 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	// make sure blob tx to the batch inbox is ignored if not signed by the batcher
 	blobTx, _ = types.SignNewTx(testutils.RandomKey(), signer, blobTxData)
 	txs = types.Transactions{blobTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, nil)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, nil, false)
 	require.Equal(t, 0, len(data))
 	require.Equal(t, 0, len(blobHashes))
 
@@ -81,7 +81,7 @@ func TestDataAndHashesFromTxs(t *testing.T) {
 	blobTxData.To = testutils.RandomAddress(rng)
 	blobTx, _ = types.SignNewTx(privateKey, signer, blobTxData)
 	txs = types.Transactions{blobTx}
-	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, nil)
+	data, blobHashes = dataAndHashesFromTxs(txs, &config, batcherAddr, nil, false)
 	require.Equal(t, 0, len(data))
 	require.Equal(t, 0, len(blobHashes))
 }

--- a/op-node/rollup/derive/calldata_source_test.go
+++ b/op-node/rollup/derive/calldata_source_test.go
@@ -158,7 +158,7 @@ func TestDataFromEVMTransactions(t *testing.T) {
 			}
 		}
 
-		out := DataFromEVMTransactions(DataSourceConfig{cfg.L1Signer(), cfg.BatchInboxAddress, false}, batcherAddr, txs, testlog.Logger(t, log.LevelCrit), daClient)
+		out := DataFromEVMTransactions(DataSourceConfig{cfg.L1Signer(), cfg.BatchInboxAddress, false}, batcherAddr, txs, testlog.Logger(t, log.LevelCrit), daClient, false)
 		require.ElementsMatch(t, expectedData, out)
 	}
 

--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -44,16 +44,17 @@ type PlasmaInputFetcher interface {
 // batch submitter transactions.
 // This is not a stage in the pipeline, but a wrapper for another stage in the pipeline
 type DataSourceFactory struct {
-	log           log.Logger
-	dsCfg         DataSourceConfig
-	fetcher       L1Fetcher
-	blobsFetcher  L1BlobsFetcher
-	plasmaFetcher PlasmaInputFetcher
-	ecotoneTime   *uint64
-	daClient      eigenda.IEigenDA
+	log                     log.Logger
+	dsCfg                   DataSourceConfig
+	fetcher                 L1Fetcher
+	blobsFetcher            L1BlobsFetcher
+	plasmaFetcher           PlasmaInputFetcher
+	ecotoneTime             *uint64
+	daClient                eigenda.IEigenDA
+	prefixDerivationEnabled bool
 }
 
-func NewDataSourceFactory(log log.Logger, cfg *rollup.Config, fetcher L1Fetcher, blobsFetcher L1BlobsFetcher, plasmaFetcher PlasmaInputFetcher, daCfg *eigenda.Config) *DataSourceFactory {
+func NewDataSourceFactory(log log.Logger, cfg *rollup.Config, fetcher L1Fetcher, blobsFetcher L1BlobsFetcher, plasmaFetcher PlasmaInputFetcher, daCfg *eigenda.Config, prefixDerivationEnabled bool) *DataSourceFactory {
 	config := DataSourceConfig{
 		l1Signer:          cfg.L1Signer(),
 		batchInboxAddress: cfg.BatchInboxAddress,
@@ -69,13 +70,14 @@ func NewDataSourceFactory(log log.Logger, cfg *rollup.Config, fetcher L1Fetcher,
 	}
 
 	return &DataSourceFactory{
-		log:           log,
-		dsCfg:         config,
-		fetcher:       fetcher,
-		blobsFetcher:  blobsFetcher,
-		plasmaFetcher: plasmaFetcher,
-		ecotoneTime:   cfg.EcotoneTime,
-		daClient:      daClient,
+		log:                     log,
+		dsCfg:                   config,
+		fetcher:                 fetcher,
+		blobsFetcher:            blobsFetcher,
+		plasmaFetcher:           plasmaFetcher,
+		ecotoneTime:             cfg.EcotoneTime,
+		daClient:                daClient,
+		prefixDerivationEnabled: prefixDerivationEnabled,
 	}
 }
 
@@ -88,9 +90,9 @@ func (ds *DataSourceFactory) OpenData(ctx context.Context, ref eth.L1BlockRef, b
 		if ds.blobsFetcher == nil {
 			return nil, fmt.Errorf("ecotone upgrade active but beacon endpoint not configured")
 		}
-		src = NewBlobDataSource(ctx, ds.log, ds.dsCfg, ds.fetcher, ds.blobsFetcher, ref, batcherAddr, ds.daClient)
+		src = NewBlobDataSource(ctx, ds.log, ds.dsCfg, ds.fetcher, ds.blobsFetcher, ref, batcherAddr, ds.daClient, ds.prefixDerivationEnabled)
 	} else {
-		src = NewCalldataSource(ctx, ds.log, ds.dsCfg, ds.fetcher, ref, batcherAddr, ds.daClient)
+		src = NewCalldataSource(ctx, ds.log, ds.dsCfg, ds.fetcher, ref, batcherAddr, ds.daClient, ds.prefixDerivationEnabled)
 	}
 	if ds.dsCfg.plasmaEnabled {
 		// plasma([calldata | blobdata](l1Ref)) -> data

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -70,11 +70,11 @@ type DerivationPipeline struct {
 
 // NewDerivationPipeline creates a derivation pipeline, which should be reset before use.
 
-func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L1Fetcher, l1Blobs L1BlobsFetcher, plasma PlasmaInputFetcher, l2Source L2Source, engine LocalEngineControl, metrics Metrics, syncCfg *sync.Config, safeHeadListener SafeHeadListener, daCfg *eigenda.Config) *DerivationPipeline {
+func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L1Fetcher, l1Blobs L1BlobsFetcher, plasma PlasmaInputFetcher, l2Source L2Source, engine LocalEngineControl, metrics Metrics, syncCfg *sync.Config, safeHeadListener SafeHeadListener, daCfg *eigenda.Config, prefixDerivationEnabled bool) *DerivationPipeline {
 
 	// Pull stages
 	l1Traversal := NewL1Traversal(log, rollupCfg, l1Fetcher)
-	dataSrc := NewDataSourceFactory(log, rollupCfg, l1Fetcher, l1Blobs, plasma, daCfg) // auxiliary stage for L1Retrieval
+	dataSrc := NewDataSourceFactory(log, rollupCfg, l1Fetcher, l1Blobs, plasma, daCfg, prefixDerivationEnabled) // auxiliary stage for L1Retrieval
 	l1Src := NewL1Retrieval(log, dataSrc, l1Traversal)
 	frameQueue := NewFrameQueue(log, l1Src)
 	bank := NewChannelBank(log, rollupCfg, frameQueue, l1Fetcher, metrics)

--- a/op-node/rollup/derive/plasma_data_source_test.go
+++ b/op-node/rollup/derive/plasma_data_source_test.go
@@ -96,7 +96,7 @@ func TestPlasmaDataSource(t *testing.T) {
 
 	signer := cfg.L1Signer()
 
-	factory := NewDataSourceFactory(logger, cfg, l1F, nil, da, nil)
+	factory := NewDataSourceFactory(logger, cfg, l1F, nil, da, nil, false)
 
 	nc := 0
 	firstChallengeExpirationBlock := uint64(95)
@@ -328,7 +328,7 @@ func TestPlasmaDataSourceStall(t *testing.T) {
 
 	signer := cfg.L1Signer()
 
-	factory := NewDataSourceFactory(logger, cfg, l1F, nil, da, nil)
+	factory := NewDataSourceFactory(logger, cfg, l1F, nil, da, nil, false)
 
 	parent := l1Refs[0]
 	// create a new mock l1 ref
@@ -443,7 +443,7 @@ func TestPlasmaDataSourceInvalidData(t *testing.T) {
 
 	signer := cfg.L1Signer()
 
-	factory := NewDataSourceFactory(logger, cfg, l1F, nil, da, nil)
+	factory := NewDataSourceFactory(logger, cfg, l1F, nil, da, nil, false)
 
 	parent := l1Refs[0]
 	// create a new mock l1 ref

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -132,6 +132,7 @@ func NewDriver(
 	sequencerConductor conductor.SequencerConductor,
 	plasma derive.PlasmaInputFetcher,
 	daCfg *eigenda.Config,
+	prefixDerivationEnabled bool,
 ) *Driver {
 	l1 = NewMeteredL1Fetcher(l1, metrics)
 	l1State := NewL1State(log, metrics)
@@ -139,7 +140,7 @@ func NewDriver(
 	findL1Origin := NewL1OriginSelector(log, cfg, sequencerConfDepth)
 	verifConfDepth := NewConfDepth(driverCfg.VerifierConfDepth, l1State.L1Head, l1)
 	engine := derive.NewEngineController(l2, log, metrics, cfg, syncCfg.SyncMode)
-	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, plasma, l2, engine, metrics, syncCfg, safeHeadListener, daCfg)
+	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, plasma, l2, engine, metrics, syncCfg, safeHeadListener, daCfg, prefixDerivationEnabled)
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
 	meteredEngine := NewMeteredEngine(cfg, engine, metrics, log) // Only use the metered engine in the sequencer b/c it records sequencing metrics.
 	sequencer := NewSequencer(log, cfg, meteredEngine, attrBuilder, findL1Origin, metrics)

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -119,7 +119,8 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 
 		Plasma: plasma.ReadCLIConfig(ctx),
 
-		DA: daCfg,
+		DA:                      daCfg,
+		PrefixDerivationEnabled: ctx.Bool(flags.PrefixDerivationEnabledFlag.Name),
 	}
 
 	if err := cfg.LoadPersisted(log); err != nil {

--- a/op-program/client/driver/driver.go
+++ b/op-program/client/driver/driver.go
@@ -40,9 +40,9 @@ type Driver struct {
 	targetBlockNum uint64
 }
 
-func NewDriver(logger log.Logger, cfg *rollup.Config, l1Source derive.L1Fetcher, l1BlobsSource derive.L1BlobsFetcher, l2Source L2Source, targetBlockNum uint64, daCfg *eigenda.Config) *Driver {
+func NewDriver(logger log.Logger, cfg *rollup.Config, l1Source derive.L1Fetcher, l1BlobsSource derive.L1BlobsFetcher, l2Source L2Source, targetBlockNum uint64, daCfg *eigenda.Config, prefixDerivationEnabled bool) *Driver {
 	engine := derive.NewEngineController(l2Source, logger, metrics.NoopMetrics, cfg, sync.CLSync)
-	pipeline := derive.NewDerivationPipeline(logger, cfg, l1Source, l1BlobsSource, plasma.Disabled, l2Source, engine, metrics.NoopMetrics, &sync.Config{}, safedb.Disabled, daCfg)
+	pipeline := derive.NewDerivationPipeline(logger, cfg, l1Source, l1BlobsSource, plasma.Disabled, l2Source, engine, metrics.NoopMetrics, &sync.Config{}, safedb.Disabled, daCfg, prefixDerivationEnabled)
 	pipeline.Reset()
 	return &Driver{
 		logger:         logger,

--- a/op-program/client/program.go
+++ b/op-program/client/program.go
@@ -63,7 +63,7 @@ func RunProgram(logger log.Logger, preimageOracle io.ReadWriter, preimageHinter 
 }
 
 // runDerivation executes the L2 state transition, given a minimal interface to retrieve data.
-func runDerivation(logger log.Logger, cfg *rollup.Config, daCfg *eigenda.Config, l2Cfg *params.ChainConfig, l1Head common.Hash, l2OutputRoot common.Hash, l2Claim common.Hash, l2ClaimBlockNum uint64, l1Oracle l1.Oracle, l2Oracle l2.Oracle) error {
+func runDerivation(logger log.Logger, cfg *rollup.Config, daCfg *eigenda.Config, prefixDerivationEnabled bool, l2Cfg *params.ChainConfig, l1Head common.Hash, l2OutputRoot common.Hash, l2Claim common.Hash, l2ClaimBlockNum uint64, l1Oracle l1.Oracle, l2Oracle l2.Oracle) error {
 	l1Source := l1.NewOracleL1Client(logger, l1Oracle, l1Head)
 	l1BlobsSource := l1.NewBlobFetcher(logger, l1Oracle)
 	engineBackend, err := l2.NewOracleBackedL2Chain(logger, l2Oracle, l1Oracle /* kzg oracle */, l2Cfg, l2OutputRoot)
@@ -73,7 +73,7 @@ func runDerivation(logger log.Logger, cfg *rollup.Config, daCfg *eigenda.Config,
 	l2Source := l2.NewOracleEngine(cfg, logger, engineBackend)
 
 	logger.Info("Starting derivation")
-	d := cldr.NewDriver(logger, cfg, l1Source, l1BlobsSource, l2Source, l2ClaimBlockNum, daCfg)
+	d := cldr.NewDriver(logger, cfg, l1Source, l1BlobsSource, l2Source, l2ClaimBlockNum, daCfg, prefixDerivationEnabled)
 	for {
 		if err = d.Step(context.Background()); errors.Is(err, io.EOF) {
 			break

--- a/op-service/eigenda/derivation.go
+++ b/op-service/eigenda/derivation.go
@@ -1,0 +1,5 @@
+package eigenda
+
+// Useful to dinstiguish between plain calldata and alt-da blob refs
+// Support seamless migration of existing rollups using ETH DA
+const DerivationVersionEigenda = 0xed


### PR DESCRIPTION
Add prefix derivation support for data posting via `DA_PREFIX_DERIVATION_ENABLED` flag.

It allows seamless migration of existing rollups to EigenDA without particular forking techniques.

It prepends the byte `0xed` to batcher data on EigenDA successful submission and the Optimism vanilla one ('0x00') when fallback to Ethereum calldata.

It's recommended to toggle the default flag to true in a next major release. In this PR it's false.